### PR TITLE
Fix navigation flow compilation issues

### DIFF
--- a/RayLink/App/RayLinkApp.swift
+++ b/RayLink/App/RayLinkApp.swift
@@ -7,12 +7,12 @@ import Combine
 struct RayLinkApp: App {
     @StateObject private var container = DependencyContainer.shared
     @StateObject private var coordinator = NavigationCoordinator()
-    
+
     init() {
         setupAppearance()
         requestVPNPermissions()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: $coordinator.path) {
@@ -28,19 +28,19 @@ struct RayLinkApp: App {
             }
         }
     }
-    
+
     private func setupAppearance() {
         // Configure app-wide appearance
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = UIColor(AppTheme.Colors.background)
         appearance.titleTextAttributes = [.foregroundColor: UIColor(AppTheme.Colors.primary)]
-        
+
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
     }
-    
+
     private func requestVPNPermissions() {
         Task {
             do {
@@ -49,43 +49,5 @@ struct RayLinkApp: App {
                 print("Failed to load VPN preferences: \(error)")
             }
         }
-    }
-}
-
-struct ContentView: View {
-    @EnvironmentObject var coordinator: NavigationCoordinator
-    @EnvironmentObject var container: DependencyContainer
-    @State private var selectedTab = 0
-    
-    var body: some View {
-        TabView(selection: $selectedTab) {
-            NavigationStack {
-                HomeView()
-            }
-            .tabItem {
-                Image(systemName: "house.fill")
-                Text("Home")
-            }
-            .tag(0)
-            
-            NavigationStack {
-                ServerListView()
-            }
-            .tabItem {
-                Image(systemName: "list.bullet")
-                Text("Servers")
-            }
-            .tag(1)
-            
-            NavigationStack {
-                SettingsView()
-            }
-            .tabItem {
-                Image(systemName: "gearshape.fill")
-                Text("Settings")
-            }
-            .tag(2)
-        }
-        .accentColor(AppTheme.Colors.primary)
     }
 }

--- a/RayLink/ContentView.swift
+++ b/RayLink/ContentView.swift
@@ -1,11 +1,50 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject private var coordinator: NavigationCoordinator
+
+    private var selectionBinding: Binding<Int> {
+        Binding(
+            get: { coordinator.selectedTab },
+            set: { newValue in
+                if let tab = NavigationCoordinator.Tab(rawValue: newValue) {
+                    coordinator.selectTab(tab)
+                } else {
+                    coordinator.selectedTab = newValue
+                }
+            }
+        )
+    }
+
     var body: some View {
-        MainView()
+        TabView(selection: selectionBinding) {
+            HomeView()
+                .tabItem {
+                    Image(systemName: NavigationCoordinator.Tab.home.selectedIcon)
+                    Text(NavigationCoordinator.Tab.home.title)
+                }
+                .tag(NavigationCoordinator.Tab.home.rawValue)
+
+            ServerListView()
+                .tabItem {
+                    Image(systemName: NavigationCoordinator.Tab.servers.selectedIcon)
+                    Text(NavigationCoordinator.Tab.servers.title)
+                }
+                .tag(NavigationCoordinator.Tab.servers.rawValue)
+
+            SettingsView()
+                .tabItem {
+                    Image(systemName: NavigationCoordinator.Tab.settings.selectedIcon)
+                    Text(NavigationCoordinator.Tab.settings.title)
+                }
+                .tag(NavigationCoordinator.Tab.settings.rawValue)
+        }
+        .tint(AppTheme.Colors.primary)
     }
 }
 
 #Preview {
     ContentView()
+        .environmentObject(DependencyContainer.shared)
+        .environmentObject(NavigationCoordinator())
 }

--- a/RayLink/Core/DependencyContainer.swift
+++ b/RayLink/Core/DependencyContainer.swift
@@ -355,7 +355,7 @@ final class SpeedTestService: SpeedTestServiceProtocol {
     }
 }
 
-public struct SpeedTestResult: Codable {
+public struct SpeedTestResult: Codable, Hashable {
     let downloadSpeed: Double // Mbps
     let uploadSpeed: Double // Mbps
     let ping: Int // ms

--- a/RayLink/Core/NavigationCoordinator.swift
+++ b/RayLink/Core/NavigationCoordinator.swift
@@ -4,12 +4,89 @@ import Combine
 // Global types imported via RayLinkTypes
 
 // MARK: - Navigation Destination
-enum NavigationDestination: Hashable {
+enum NavigationDestination: Hashable, Identifiable {
     case home
     case serverList
+    case serverDetail(VPNServer)
     case addServer
+    case editServer(VPNServer)
     case settings
+    case settingsSection(SettingsSection)
     case importConfig
+    case importConfigResult([VPNServer])
+    case speedTest
+    case speedTestResult(SpeedTestResult)
+    case logs
+    case about
+    case help
+    case subscription
+    case addSubscription
+    case trustedNetworks
+    case routingRules
+    case dataUsage
+    case privacy
+    case diagnostics
+    case backup
+
+    enum SettingsSection: Hashable {
+        case connection
+        case privacy
+        case advanced
+        case appearance
+        case notifications
+        case subscription
+        case about
+    }
+
+    var id: String {
+        switch self {
+        case .home:
+            return "home"
+        case .serverList:
+            return "serverList"
+        case .serverDetail(let server):
+            return "serverDetail-\(server.id)"
+        case .addServer:
+            return "addServer"
+        case .editServer(let server):
+            return "editServer-\(server.id)"
+        case .settings:
+            return "settings"
+        case .settingsSection(let section):
+            return "settingsSection-\(section)"
+        case .importConfig:
+            return "importConfig"
+        case .importConfigResult(let servers):
+            let hash = servers.map { $0.id }.joined(separator: "-")
+            return "importConfigResult-\(hash)"
+        case .speedTest:
+            return "speedTest"
+        case .speedTestResult(let result):
+            return "speedTestResult-\(result.timestamp.timeIntervalSince1970)"
+        case .logs:
+            return "logs"
+        case .about:
+            return "about"
+        case .help:
+            return "help"
+        case .subscription:
+            return "subscription"
+        case .addSubscription:
+            return "addSubscription"
+        case .trustedNetworks:
+            return "trustedNetworks"
+        case .routingRules:
+            return "routingRules"
+        case .dataUsage:
+            return "dataUsage"
+        case .privacy:
+            return "privacy"
+        case .diagnostics:
+            return "diagnostics"
+        case .backup:
+            return "backup"
+        }
+    }
 }
 
 // MARK: - Navigation Coordinator
@@ -73,18 +150,13 @@ public final class NavigationCoordinator: ObservableObject {
     func navigate(to destination: NavigationDestination) {
         switch destination {
         case .home:
-            selectedTab = Tab.home.rawValue
-            path = NavigationPath()
+            selectTab(.home)
         case .serverList:
-            selectedTab = Tab.servers.rawValue
-            path = NavigationPath()
+            selectTab(.servers)
         case .settings:
-            selectedTab = Tab.settings.rawValue
-            path = NavigationPath()
-        case .addServer, .importConfig, .speedTest:
-            presentSheet(destination)
+            selectTab(.settings)
         default:
-            path.append(destination)
+            push(destination)
         }
     }
     
@@ -142,7 +214,7 @@ public final class NavigationCoordinator: ObservableObject {
                 self.dismissSheet()
             }
         case .editServer(let server):
-            EditServerView(server: server) { updatedServer in
+            EditServerView(server: server) { _ in
                 // Handle server update
                 self.dismissSheet()
             }
@@ -167,7 +239,7 @@ public final class NavigationCoordinator: ObservableObject {
         case .subscription:
             SubscriptionView()
         case .addSubscription:
-            AddSubscriptionView()
+            AddSubscriptionView { _ in }
         case .trustedNetworks:
             TrustedNetworksView()
         case .routingRules:
@@ -182,7 +254,7 @@ public final class NavigationCoordinator: ObservableObject {
             BackupView()
         }
     }
-    
+
     @ViewBuilder
     private func settingsView(for section: NavigationDestination.SettingsSection) -> some View {
         switch section {

--- a/RayLink/Features/Common/NavigationDestinationViews.swift
+++ b/RayLink/Features/Common/NavigationDestinationViews.swift
@@ -1,0 +1,490 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Server Management
+struct ServerDetailView: View {
+    let server: VPNServer
+
+    var body: some View {
+        List {
+            Section("Connection") {
+                detailRow(title: "Address", value: server.address)
+                detailRow(title: "Port", value: String(server.port))
+                detailRow(title: "Protocol", value: server.serverProtocol.rawValue.uppercased())
+                if server.ping > 0 {
+                    detailRow(title: "Ping", value: "\(server.ping) ms")
+                }
+            }
+
+            if let country = server.country {
+                Section("Location") {
+                    detailRow(title: "Country", value: country)
+                    if let city = server.city {
+                        detailRow(title: "City", value: city)
+                    }
+                }
+            }
+
+            if !server.tags.isEmpty {
+                Section("Tags") {
+                    Text(server.tags.joined(separator: ", "))
+                }
+            }
+        }
+        .navigationTitle(server.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func detailRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+        }
+    }
+}
+
+struct EditServerView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var address: String
+    @State private var port: String
+    @State private var selectedProtocol: VPNProtocol
+    @State private var username: String
+    @State private var password: String
+    @State private var uuid: String
+
+    private let originalServer: VPNServer
+    let onSave: (VPNServer) -> Void
+
+    init(server: VPNServer, onSave: @escaping (VPNServer) -> Void) {
+        self.originalServer = server
+        self._name = State(initialValue: server.name)
+        self._address = State(initialValue: server.address)
+        self._port = State(initialValue: String(server.port))
+        self._selectedProtocol = State(initialValue: server.serverProtocol)
+        self._username = State(initialValue: server.username ?? "")
+        self._password = State(initialValue: server.password ?? "")
+        self._uuid = State(initialValue: server.uuid ?? "")
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        Form {
+            Section("Server") {
+                TextField("Name", text: $name)
+                TextField("Address", text: $address)
+                TextField("Port", text: $port)
+                    .keyboardType(.numberPad)
+
+                Picker("Protocol", selection: $selectedProtocol) {
+                    ForEach(VPNProtocol.allCases, id: \.self) { protocolOption in
+                        Text(protocolOption.rawValue.capitalized).tag(protocolOption)
+                    }
+                }
+            }
+
+            Section("Credentials") {
+                TextField("Username", text: $username)
+                SecureField("Password", text: $password)
+                TextField("UUID", text: $uuid)
+            }
+        }
+        .navigationTitle("Edit Server")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") { save() }
+                    .disabled(!isValid)
+            }
+        }
+    }
+
+    private var isValid: Bool {
+        guard let portValue = Int(port), portValue > 0 && portValue <= 65535 else {
+            return false
+        }
+        return !name.isEmpty && !address.isEmpty
+    }
+
+    private func save() {
+        guard let portValue = Int(port) else { return }
+
+        let updated = VPNServer(
+            id: originalServer.id,
+            name: name,
+            address: address,
+            port: portValue,
+            serverProtocol: selectedProtocol,
+            username: username.isEmpty ? nil : username,
+            password: password.isEmpty ? nil : password,
+            uuid: uuid.isEmpty ? nil : uuid,
+            ping: originalServer.ping,
+            isActive: originalServer.isActive,
+            country: originalServer.country,
+            city: originalServer.city,
+            region: originalServer.region,
+            countryCode: originalServer.countryCode,
+            provider: originalServer.provider,
+            tags: originalServer.tags
+        )
+
+        onSave(updated)
+        dismiss()
+    }
+}
+
+struct ImportResultView: View {
+    let servers: [VPNServer]
+
+    var body: some View {
+        List {
+            Section("Imported Servers") {
+                ForEach(servers) { server in
+                    VStack(alignment: .leading) {
+                        Text(server.name)
+                            .font(.headline)
+                        Text("\(server.address):\(server.port)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Import Summary")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct SpeedTestResultView: View {
+    let result: SpeedTestResult
+
+    var body: some View {
+        List {
+            Section("Performance") {
+                detailRow("Download", value: result.downloadSpeedFormatted)
+                detailRow("Upload", value: result.uploadSpeedFormatted)
+                detailRow("Latency", value: "\(result.ping) ms")
+                detailRow("Grade", value: result.grade.rawValue)
+            }
+
+            Section("Timestamp") {
+                detailRow("Completed", value: format(date: result.timestamp))
+            }
+        }
+        .navigationTitle("Speed Test Result")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func detailRow(_ title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func format(date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Informational Views
+struct LogsView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+
+            Text("Diagnostics Logs")
+                .font(.title2.bold())
+
+            Text("Log collection is not yet available in this build. Connect to a server and return later to view runtime information.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .navigationTitle("Logs")
+    }
+}
+
+struct AboutView: View {
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    var body: some View {
+        List {
+            Section("RayLink") {
+                LabeledContent("Version", value: appVersion)
+                LabeledContent("Build", value: buildNumber)
+            }
+
+            Section("Credits") {
+                Text("RayLink is an open-source VPN client prototype showcasing modern SwiftUI techniques and a modular architecture.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("About")
+    }
+}
+
+struct HelpView: View {
+    var body: some View {
+        List {
+            Section("Support") {
+                Label("Visit Documentation", systemImage: "book")
+                Label("Contact Support", systemImage: "envelope")
+                Label("Join the Community", systemImage: "person.2")
+            }
+        }
+        .navigationTitle("Help")
+    }
+}
+
+struct SubscriptionView: View {
+    @EnvironmentObject private var container: DependencyContainer
+    @State private var subscriptions: [VPNSubscription] = []
+    @State private var isLoading = false
+
+    var body: some View {
+        List {
+            if subscriptions.isEmpty {
+                Section {
+                    VStack(spacing: 12) {
+                        Image(systemName: "link")
+                            .font(.system(size: 36))
+                            .foregroundStyle(.secondary)
+                        Text("No subscriptions yet")
+                            .font(.headline)
+                        Text("Add a subscription to keep your server list up to date.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 32)
+                }
+            } else {
+                Section("Subscriptions") {
+                    ForEach(subscriptions) { subscription in
+                        SubscriptionRowView(subscription: subscription)
+                    }
+                }
+            }
+        }
+        .overlay {
+            if isLoading {
+                ProgressView().progressViewStyle(.circular)
+            }
+        }
+        .navigationTitle("Subscriptions")
+        .task(load)
+    }
+
+    private func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            if let stored = try container.storageManager.load([VPNSubscription].self, for: .subscriptions) {
+                await MainActor.run { subscriptions = stored }
+            } else {
+                await MainActor.run { subscriptions = [] }
+            }
+        } catch {
+            await MainActor.run { subscriptions = [] }
+        }
+    }
+}
+
+struct RoutingRulesView: View {
+    var body: some View {
+        List {
+            Section("Routing") {
+                Text("Custom routing rules are not yet available in this build.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+        }
+        .navigationTitle("Routing Rules")
+    }
+}
+
+struct PrivacyView: View {
+    var body: some View {
+        List {
+            Section("Privacy") {
+                Toggle("Send Anonymous Diagnostics", isOn: .constant(false))
+                Toggle("Share Usage Data", isOn: .constant(false))
+            }
+        }
+        .navigationTitle("Privacy")
+    }
+}
+
+struct DiagnosticsView: View {
+    var body: some View {
+        List {
+            Section("Environment") {
+                LabeledContent("iOS Version", value: UIDevice.current.systemVersion)
+                LabeledContent("Device", value: UIDevice.current.model)
+            }
+
+            Section("Status") {
+                Text("Diagnostics collection is under development.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Diagnostics")
+    }
+}
+
+struct BackupView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "externaldrive.badge.icloud")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+
+            Text("Backup & Restore")
+                .font(.title2.bold())
+
+            Text("Use iCloud Drive to export your configuration. This feature is planned for a future milestone.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .navigationTitle("Backup")
+    }
+}
+
+// MARK: - Settings Sections
+struct ConnectionSettingsView: View {
+    @State private var autoConnect = false
+    @State private var connectOnDemand = false
+    @State private var selectedProtocol = VPNProtocol.shadowsocks
+
+    var body: some View {
+        Form {
+            Toggle("Auto Connect", isOn: $autoConnect)
+            Toggle("Connect on Demand", isOn: $connectOnDemand)
+
+            Picker("Preferred Protocol", selection: $selectedProtocol) {
+                ForEach(VPNProtocol.allCases, id: \.self) { option in
+                    Text(option.rawValue.capitalized).tag(option)
+                }
+            }
+        }
+        .navigationTitle("Connection")
+    }
+}
+
+struct PrivacySettingsView: View {
+    @State private var analyticsEnabled = false
+    @State private var crashReportsEnabled = true
+
+    var body: some View {
+        Form {
+            Toggle("Share Analytics", isOn: $analyticsEnabled)
+            Toggle("Crash Reports", isOn: $crashReportsEnabled)
+
+            Section("Data Retention") {
+                Toggle("Keep Usage History", isOn: .constant(true))
+                Toggle("Clear Logs on Disconnect", isOn: .constant(true))
+            }
+        }
+        .navigationTitle("Privacy")
+    }
+}
+
+struct AdvancedSettingsView: View {
+    @State private var enableParallelConnections = false
+    @State private var enableDomainStrategy = false
+
+    var body: some View {
+        Form {
+            Toggle("Parallel Connections", isOn: $enableParallelConnections)
+            Toggle("Advanced Routing", isOn: $enableDomainStrategy)
+
+            Section("Debug") {
+                Toggle("Verbose Logging", isOn: .constant(false))
+            }
+        }
+        .navigationTitle("Advanced")
+    }
+}
+
+struct AppearanceSettingsView: View {
+    @State private var useDarkMode = true
+    @State private var showAnimations = true
+
+    var body: some View {
+        Form {
+            Toggle("Dark Mode", isOn: $useDarkMode)
+            Toggle("Animated Backgrounds", isOn: $showAnimations)
+
+            Section("Theme") {
+                Picker("Accent", selection: .constant("Aurora")) {
+                    Text("Aurora").tag("Aurora")
+                    Text("Ocean").tag("Ocean")
+                    Text("Sunset").tag("Sunset")
+                }
+            }
+        }
+        .navigationTitle("Appearance")
+    }
+}
+
+struct NotificationSettingsView: View {
+    @State private var connectionAlerts = true
+    @State private var subscriptionAlerts = true
+
+    var body: some View {
+        Form {
+            Toggle("Connection Alerts", isOn: $connectionAlerts)
+            Toggle("Subscription Updates", isOn: $subscriptionAlerts)
+
+            Section("Quiet Hours") {
+                Toggle("Enable", isOn: .constant(false))
+            }
+        }
+        .navigationTitle("Notifications")
+    }
+}
+
+struct SubscriptionSettingsView: View {
+    @State private var autoRefresh = true
+    @State private var refreshInterval = SubscriptionUpdateInterval.hours6
+
+    var body: some View {
+        Form {
+            Toggle("Auto Refresh", isOn: $autoRefresh)
+
+            Picker("Interval", selection: $refreshInterval) {
+                ForEach(SubscriptionUpdateInterval.allCases) { interval in
+                    Text(interval.displayName).tag(interval)
+                }
+            }
+            .disabled(!autoRefresh)
+        }
+        .navigationTitle("Subscriptions")
+    }
+}

--- a/RayLink/Features/Home/HomeView.swift
+++ b/RayLink/Features/Home/HomeView.swift
@@ -189,7 +189,7 @@ public struct HomeView: View {
             
             // Add/Import button
             Button(action: {
-                coordinator.navigate(to: .import)
+                coordinator.navigate(to: .importConfig)
             }) {
                 Image(systemName: "plus")
                     .font(.system(size: 20, weight: .medium))

--- a/RayLink/Features/ServerList/ServerListView.swift
+++ b/RayLink/Features/ServerList/ServerListView.swift
@@ -45,7 +45,7 @@ struct ServerListView: View {
                             } else if filteredGroups.isEmpty {
                                 EmptyServerState(
                                     onAddServer: { showingAddServer = true },
-                                    onImport: { coordinator.navigate(to: .import) }
+                                    onImport: { coordinator.navigate(to: .importConfig) }
                                 )
                                 .transition(.asymmetric(
                                     insertion: .scale.combined(with: .opacity),
@@ -113,8 +113,8 @@ struct ServerListView: View {
                             Button("Add Server") { 
                                 showingAddServer = true 
                             }
-                            Button("Import from URL") { 
-                                coordinator.navigate(to: .import) 
+                            Button("Import from URL") {
+                                coordinator.navigate(to: .importConfig)
                             }
                             Divider()
                             Button("Refresh All") { 

--- a/RayLink/Models/VPNServer.swift
+++ b/RayLink/Models/VPNServer.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // MARK: - VPN Server Model
-struct VPNServer: Codable, Identifiable, Equatable {
+struct VPNServer: Codable, Identifiable, Equatable, Hashable {
     let id: String
     var name: String
     let address: String
@@ -49,6 +49,13 @@ struct VPNServer: Codable, Identifiable, Equatable {
 
     static func == (lhs: VPNServer, rhs: VPNServer) -> Bool {
         lhs.id == rhs.id && lhs.address == rhs.address && lhs.port == rhs.port && lhs.serverProtocol == rhs.serverProtocol
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(address)
+        hasher.combine(port)
+        hasher.combine(serverProtocol)
     }
     
     init(

--- a/RayLink/RayLink.xcodeproj/project.pbxproj
+++ b/RayLink/RayLink.xcodeproj/project.pbxproj
@@ -247,7 +247,9 @@
 		<key>4F3D761953BE4D7A80DF92DC</key>
 		<dict>
 			<key>children</key>
-			<array/>
+			<array>
+				<string>3D74BCA6FA644803ACB7440D</string>
+			</array>
 			<key>isa</key>
 			<string>PBXGroup</string>
 			<key>path</key>
@@ -1016,9 +1018,49 @@
 			<string>2147483647</string>
 			<key>files</key>
 			<array>
+				<string>8C677457DDBE47FA94FD15B3</string>
+				<string>1EE129F13B904A01BF502CBE</string>
+				<string>3BBF8330EAD94ED285CCF83C</string>
+				<string>CEE8E404EAEB4F069BB37E2F</string>
+				<string>70EC25D02A45473C960BBD20</string>
 				<string>A1234567890123456789012C</string>
-				<string>A1234567890123456789012A</string>
+				<string>4C0E21ECE8D94529ABBEB8B7</string>
+				<string>D0C03034D5AA49B88E976044</string>
+				<string>297322EB42C0406F9AAFEAA4</string>
+				<string>A03938E20F3840EDA32BEB12</string>
+				<string>F5F5C95F014C44F882AE3769</string>
+				<string>A1234567890123456789013C</string>
+				<string>48E3459ACA8B44ACB957916E</string>
+				<string>A1234567890123456789014C</string>
+				<string>CE8A1E8942D04825A7A2DDA7</string>
+				<string>568FEC2D232A404DB7BAB9D2</string>
+				<string>53B451EB8B4345DCBA534B1D</string>
 				<string>26C4970AF7BB44CA8D27CA1B</string>
+				<string>33D2C68E0CB248D68EC902FA</string>
+				<string>916286BE76704BB59ED6F02B</string>
+				<string>8624E87ED2884659BAF7240F</string>
+				<string>77094561EC184394A1AA8320</string>
+				<string>DC9C391540034E5180496A93</string>
+				<string>820BC1D64A13414CA1E33E85</string>
+				<string>AA78931BD4C04499BB04D956</string>
+				<string>7C62D5A0FEF646C0862E9621</string>
+				<string>A1234567890123456789012A</string>
+				<string>919B0AC050D049A7AA3B2427</string>
+				<string>96E14A96174A48DEA0AEBABC</string>
+				<string>A1234567890123456789013E</string>
+				<string>972433D66E7D4AFE95D7DA6F</string>
+				<string>1C4DB3E4CD2A48189438E2FD</string>
+				<string>098D3513D4884F57B0BC8C20</string>
+				<string>A1234567890123456789014A</string>
+				<string>0EAB74488E134872BC6CA061</string>
+				<string>9AC7043B2DA74D208F092BC8</string>
+				<string>2BAFB098C9AF4F71A9BB24B1</string>
+				<string>ACE41464869243C09F272648</string>
+				<string>2F903011066C4A5FABB89E74</string>
+				<string>8ADE15B2D1ED49EDA0311926</string>
+				<string>EFC0C91720DC4689B045A9DD</string>
+				<string>91D9BE4B5F384C9FBA9D5BA6</string>
+				<string>0ADC358E854A4394ABFD3C20</string>
 			</array>
 			<key>isa</key>
 			<string>PBXSourcesBuildPhase</string>
@@ -1760,6 +1802,24 @@
 			<string>ConnectionStats.swift</string>
 			<key>sourceTree</key>
 			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3D74BCA6FA644803ACB7440D</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>NavigationDestinationViews.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8624E87ED2884659BAF7240F</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>fileRef</key>
+			<string>3D74BCA6FA644803ACB7440D</string>
 		</dict>
 	</dict>
 	<key>rootObject</key>

--- a/Tests/RayLinkTests/RayLinkTests.swift
+++ b/Tests/RayLinkTests/RayLinkTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import RayLink
+
+final class RayLinkTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- move the tab scaffold into the dedicated `ContentView` and simplify the app entry point
- expand the navigation coordinator with the full destination enum plus lightweight placeholder screens
- adjust models and supporting types so the new destinations are hashable and add a stub test target for SwiftPM
- include the navigation support views and the rest of the Swift sources in the Xcode target so ContentView resolves all symbols

## Testing
- `swift build` *(fails: SwiftUI/Foundation headers unavailable in Linux toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9ff4ed008328b3f59282de60214a